### PR TITLE
always look for .jar in same folder as .bat

### DIFF
--- a/resources/Whitebox.bat
+++ b/resources/Whitebox.bat
@@ -1,1 +1,1 @@
-java -jar WhiteboxGIS.jar
+java -jar %~dp0\WhiteboxGIS.jar


### PR DESCRIPTION
Enables calling the batch file from anywhere (don't need to set current dir first).
Uses Parameter Expansion - https://ss64.com/nt/syntax-args.html